### PR TITLE
cuda-nvtx v13.1.115

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -8,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -139,12 +139,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -171,7 +171,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/cuda-nvtx-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cuda-nvtx" %}
-{% set version = "13.1.68" %}
+{% set version = "13.1.115" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -18,9 +18,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvtx/{{ platform }}/cuda_nvtx-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 632a0d3533f96f81440cda92c33189850694e82833c9aeba9706339476d36642  # [linux64]
-  sha256: 0e070f6569f312000ec5a1a1327d12a8925e154f0d9af4486c7a0593bd6214e2  # [aarch64]
-  sha256: 8436498a474cf7693174bceac9a112820b5630befe39aeacb2cca8a730d96659  # [win]
+  sha256: 364b3e77f2c0fa349611585aa8e148942501d924657a6afa05d0bcc4d2f8dc58  # [linux64]
+  sha256: 2f326478007d636da7e2202db3e3d56b34f510afa7559a896bfe000692e4caa2  # [aarch64]
+  sha256: 50dfce110f6dc2bf7f0777bc637401212090c4bcc0402821741f6216f971d68e  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-nvtx" %}
-{% set version = "13.0.85" %}
-{% set cuda_version = "13.0" %}
+{% set version = "13.1.68" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -18,9 +18,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvtx/{{ platform }}/cuda_nvtx-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: ed150e6fb1b50663ff068cccee3c5e2ca581c3b939b321656afbc9193671137d  # [linux64]
-  sha256: 6f50a3729091aa5a0ae61cda979ea020e09aeb7c07cec0c8962949599d2b72c6  # [aarch64]
-  sha256: 184f578d7bcce2012edf266c51dfa7834ded41464f62459f4ebcb2398cddc665  # [win]
+  sha256: 632a0d3533f96f81440cda92c33189850694e82833c9aeba9706339476d36642  # [linux64]
+  sha256: 0e070f6569f312000ec5a1a1327d12a8925e154f0d9af4486c7a0593bd6214e2  # [aarch64]
+  sha256: 8436498a474cf7693174bceac9a112820b5630befe39aeacb2cca8a730d96659  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
cuda-nvtx 13.1.115

**Destination channel:** defaults

### Links

- [PKG-12012](https://anaconda.atlassian.net/browse/PKG-12012) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12012]: https://anaconda.atlassian.net/browse/PKG-12012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ