### PR TITLE
cuda-nvtx v12.9.79

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,4 @@
+# Please see the note on "arm-variant-feedstock" cbc.yaml file regarding tegra builds
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-  - tegra         # [aarch64]
+#  - tegra         # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,8 @@ source:
   sha256: b9d506ce9ba056bf171b60e9dada06fb3d8bed5453a6399d0541960bf9b81659  # [win]
 
 build:
-  number: 1
-  skip: true  # [osx or ppc64le]
+  number: 0
+  skip: true  # [osx]
 
 requirements:
   build:
@@ -39,6 +39,9 @@ outputs:
     build:
       binary_relocation: false
       skip: true  # [not linux]
+      overlinking_ignore_patterns:
+        # Workaround for LIEF's 'not a valid TAG' error
+        - '*libnvtx3*.so*'  # [linux]
     files:
       - lib/libnv*.so.*                       # [linux]
       - targets/{{ target_name }}/lib/*.so.*  # [linux]
@@ -70,12 +73,14 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: A C-based API for annotating events, code ranges, and resources
       description: |
         A C-based API for annotating events, code ranges, and resources in your
         applications. Applications which integrate NVTX can use the Visual Profiler
         to capture and visualize these events and ranges.
       doc_url: https://docs.nvidia.com/nvtx/
+      dev_url: https://github.com/NVIDIA/NVTX
 
   - name: cuda-nvtx-dev
     build:
@@ -106,24 +111,28 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: A C-based API for annotating events, code ranges, and resources
       description: |
         A C-based API for annotating events, code ranges, and resources in your
         applications. Applications which integrate NVTX can use the Visual Profiler
         to capture and visualize these events and ranges.
       doc_url: https://docs.nvidia.com/nvtx/
+      dev_url: https://github.com/NVIDIA/NVTX
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: A C-based API for annotating events, code ranges, and resources
   description: |
     A C-based API for annotating events, code ranges, and resources in your
     applications. Applications which integrate NVTX can use the Visual Profiler
     to capture and visualize these events and ranges.
   doc_url: https://docs.nvidia.com/nvtx/
+  dev_url: https://github.com/NVIDIA/NVTX
 
 extra:
   feedstock-name: cuda-nvtx


### PR DESCRIPTION
cuda-nvtx 12.9.79

**Destination channel:** defaults

### Links

- [PKG-12778](https://anaconda.atlassian.net/browse/PKG-12778) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Added `abs.yaml` for possible use of staging channels in future builds


[PKG-12778]: https://anaconda.atlassian.net/browse/PKG-12778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ